### PR TITLE
Remove 'bundled with'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,3 @@ DEPENDENCIES
   dotenv
   jdbc-jtds
   jdbc-mysql
-
-BUNDLED WITH
-   1.16.0


### PR DESCRIPTION
The 'bundled with' version is old and causes the ansible deployment to fail. I don't know the right approach? To a not Ruby person, eliminating it all together seems reasonable as I would imagine bundler is backward compatible.